### PR TITLE
Make device name selection case-insensitive

### DIFF
--- a/src/acquire-device-hal/device/hal/device.manager.cpp
+++ b/src/acquire-device-hal/device/hal/device.manager.cpp
@@ -199,7 +199,8 @@ DeviceManagerV0::get_driver(const struct DeviceIdentifier* identifier)
 const struct DeviceIdentifier*
 DeviceManagerV0::select(DeviceKind kind, const std::string& name) const
 {
-    std::regex re(name.c_str());
+    std::regex re(name.c_str(),
+                  std::regex_constants::icase | std::regex_constants::optimize);
     for (const auto& identifier : identifiers_) {
         if (identifier.identifier_.kind == kind) {
             // regex match for name


### PR DESCRIPTION
One of the things I did in the refactor was fiddle with device names, sometimes changing the case. This PR makes the regex use case insensitive matching.

A possible downside to this change is that it makes selection somewhat less specific, but I don't think we want to live in a world where "Tiff" vs "tiff" makes a meaningful difference and we should be the change we want to see.