### PR TITLE
enable fPIC for acquire-core-libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ enable_testing()
 include(cmake/aq_require.cmake)
 include(cmake/ide.cmake)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 20)
 


### PR DESCRIPTION
acquire-python tests are [failing on Ubuntu](https://github.com/acquire-project/acquire-python/actions/runs/4950559813/jobs/8854338341) asking for position-independent code. This should fix that.