### PR TITLE
silence TRACE calls in linux/platform.c

### DIFF
--- a/src/acquire-core-platform/linux/platform.c
+++ b/src/acquire-core-platform/linux/platform.c
@@ -12,7 +12,7 @@
 #define L (aq_logger)
 #define LOG(...) L(0, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
 #define LOGE(...) L(1, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
-#define TRACE(...) LOG(__VA_ARGS__)
+#define TRACE(...)
 #define EXPECT(e, ...)                                                         \
     do {                                                                       \
         if (!(e)) {                                                            \


### PR DESCRIPTION
This puts `TRACE` in platform.c on Linux at parity with the other two platforms.