### PR TITLE
Update minimum required cmake to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(acquire-core-libs)
 cmake_policy(SET CMP0079 NEW) # use targets from other directories
 enable_testing()


### PR DESCRIPTION
As of CMake 3.27, declaring a minimum supported cmake of < 3.5 generates a warning:

> Compatibility with CMake < 3.5 will be removed from a future version of CMake.

This updates the minimum required version to 3.5 accordingly.