### PR TITLE
Add spinnaker driver to device manager

### DIFF
--- a/src/acquire-device-hal/device/hal/device.manager.cpp
+++ b/src/acquire-device-hal/device/hal/device.manager.cpp
@@ -119,6 +119,7 @@ DeviceManagerV0::init(void (*reporter)(int is_error,
     drivers_.push_back(driver_load("acquire-driver-hdcam", reporter));
     drivers_.push_back(driver_load("acquire-driver-zarr", reporter));
     drivers_.push_back(driver_load("acquire-driver-egrabber", reporter));
+    drivers_.push_back(driver_load("acquire-driver-spinnaker", reporter));
 
     // enumerate devices
     const DeviceIdentifier dflt{ 0, 0, DeviceKind_Unknown, "" };


### PR DESCRIPTION
This is needed to support https://github.com/acquire-project/acquire-driver-spinnaker/pull/4 