### PR TITLE
Fix win file permissions

### DIFF
--- a/src/acquire-core-platform/linux/platform.c
+++ b/src/acquire-core-platform/linux/platform.c
@@ -36,7 +36,7 @@
 int
 file_create(struct file* file, const char* filename, size_t bytesof_filename)
 {
-    file->fid = open(filename, O_RDWR | O_CREAT | O_NONBLOCK, 0666);
+    file->fid = open(filename, O_RDWR | O_CREAT | O_EXCL | O_NONBLOCK, 0666);
     if (file->fid < 0)
         CHECK_POSIX(errno);
     return 1;

--- a/src/acquire-core-platform/osx/platform.c
+++ b/src/acquire-core-platform/osx/platform.c
@@ -44,7 +44,7 @@
 int
 file_create(struct file* file, const char* filename, size_t bytesof_filename)
 {
-    file->fid = open(filename, O_RDWR | O_CREAT | O_NONBLOCK, 0666);
+    file->fid = open(filename, O_RDWR | O_CREAT | O_EXCL | O_NONBLOCK, 0666);
     if (file->fid < 0)
         CHECK_POSIX(errno);
     return 1;

--- a/src/acquire-core-platform/win32/platform.c
+++ b/src/acquire-core-platform/win32/platform.c
@@ -74,7 +74,7 @@ file_create(struct file* file, const char* filename, size_t bytes_of_filename)
 
     CHECK_HANDLE(file->hfile = CreateFileA(filename,
                                            GENERIC_WRITE,
-                                           FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                           FILE_SHARE_READ,
                                            0,
                                            CREATE_ALWAYS,
                                            FILE_FLAG_OVERLAPPED,


### PR DESCRIPTION
It was found during testing that I could configure each video stream to write to the same tiff file and everything proceeded just fine.

Both streams happily overwrote each other's data in the one created file.  That shouldn't happen.

This PR fixes the access flag, but doesn't add a test. This should be a windows specific problem.